### PR TITLE
Repair a broken import: modtools.utils

### DIFF
--- a/source/mod_host.py
+++ b/source/mod_host.py
@@ -54,7 +54,7 @@ setInitialSettings()
 
 from mod import webserver
 from mod.session import SESSION
-from mod.utils import get_bundle_dirname, get_all_pedalboards, get_pedalboard_info
+from modtools.utils import get_bundle_dirname, get_all_pedalboards, get_pedalboard_info
 
 from mod import webserver
 


### PR DESCRIPTION
There is a runtime error at startup when the MOD packages are taken from current git master branches.
I think this must be renamed to match the current `mod-ui`.